### PR TITLE
Set unreleased version (1.23) as a prerelease

### DIFF
--- a/docs/version-1.23/antora-yml/antora-community.yml
+++ b/docs/version-1.23/antora-yml/antora-community.yml
@@ -1,7 +1,7 @@
 name: kubewarden
 title: Kubewarden
 version: 1.23
-display_version: 1.23-next
+prerelease: -next
 start_page: en:introduction.adoc
 nav:
 - modules/en/nav.adoc

--- a/docs/version-1.23/antora-yml/antora-product.yml
+++ b/docs/version-1.23/antora-yml/antora-product.yml
@@ -1,7 +1,7 @@
 name: policy-manager
 title: Policy Manager
 version: 1.23
-display_version: 1.23-next
+prerelease: -next
 start_page: en:introduction.adoc
 nav:
 - modules/en/nav.adoc


### PR DESCRIPTION
Use Antora's [prerelease](https://docs.antora.org/antora/latest/component-prerelease/) setting, so that proper routing rules are applied, for versions that haven't been released yet.