### PR TITLE
Clean remnants of old product-docs-supplemental-files submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "product-docs-supplemental-files"]
-	path = product-docs-supplemental-files
-	url = https://github.com/rancher/product-docs-supplemental-files.git
 [submodule "kw-community-docs-supp-files"]
 	path = kw-community-docs-supp-files
 	url = https://github.com/jhkrug/kw-community-docs-supp-files.git

--- a/kw-local-playbook.yml
+++ b/kw-local-playbook.yml
@@ -12,7 +12,7 @@ ui:
   bundle:
     url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true
     snapshot: true
-  supplemental_files: ./product-docs-supplemental-files
+  supplemental_files: ./dsc-style-bundle/supplemental-files/rancher
 
 asciidoc:
   attributes:

--- a/kw-remote-playbook.yml
+++ b/kw-remote-playbook.yml
@@ -12,7 +12,7 @@ ui:
   bundle:
     url: tmp/sp
     snapshot: true
-  supplemental_files: ./product-docs-supplemental-files
+  supplemental_files: ./dsc-style-bundle/supplemental-files/rancher
 
 asciidoc:
   attributes:


### PR DESCRIPTION
Dependabot updates have been [failing recently](https://github.com/rancher/kubewarden-product-docs/actions/runs/14112445632), which has resulted in submodules being outdated (e.g. dsc-style bundle is on [e8f1e169](https://github.com/susedoc/dsc-style-bundle/tree/e8f1e169ba4e49419342f46ee828b1f0b8dad806) from over 2 months ago). I suspect this is due to removing the submodule folder, but leaving behind references in the .gitmodules file.

This PR cleans the .gitmodules file and a couple other references in playbook files, which I assume should be converted to the dsc bundle as well. 