### PR TITLE
Update revdate so SU notices.

### DIFF
--- a/docs/archive/version-1.22/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/archive/version-1.22/modules/en/pages/reference/kwctl-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-06-03
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/archive/version-1.22/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/archive/version-1.22/modules/en/pages/reference/policy-server-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-02-26
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/archive/version-1.23/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/archive/version-1.23/modules/en/pages/reference/kwctl-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-06-03
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/archive/version-1.23/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/archive/version-1.23/modules/en/pages/reference/policy-server-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/archive/version-1.24/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/archive/version-1.24/modules/en/pages/reference/kwctl-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-05-05
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/archive/version-1.24/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/archive/version-1.24/modules/en/pages/reference/policy-server-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-04-15
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/version-1.25/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/version-1.25/modules/en/pages/reference/kwctl-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-05-13
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/version-1.25/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/version-1.25/modules/en/pages/reference/policy-server-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-05-12
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/version-1.26/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/version-1.26/modules/en/pages/reference/policy-server-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-05-16
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/version-1.27/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/version-1.27/modules/en/pages/reference/policy-server-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-07-09
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/version-1.28/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/version-1.28/modules/en/pages/reference/policy-server-cli.adoc
@@ -6,7 +6,7 @@
 :doc-persona: [kubewarden-operator]
 :doc-type: [reference]
 :doc-topic: [operator-manual]
-:revdate: 2025-07-09
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/version-1.29/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/version-1.29/modules/en/pages/reference/policy-server-cli.adoc
@@ -7,7 +7,7 @@
 :doc-type: [reference]
 :doc-topic: [operator-manual]
 include::partial$variables.adoc[]
-:revdate: 2025-07-09
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/version-1.30/modules/en/pages/reference/policy-server-cli.adoc
+++ b/docs/version-1.30/modules/en/pages/reference/policy-server-cli.adoc
@@ -7,7 +7,7 @@
 :doc-type: [reference]
 :doc-topic: [operator-manual]
 include::partial$variables.adoc[]
-:revdate: 2025-07-09
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = {title}


### PR DESCRIPTION
Update the revdate for those files that had heading levels changed to avoid untitled HTML docs occasionally occurring. Need a revdate bump as well, so that SU notices. Probably.