### PR TITLE
fix: quick start install from AppCo registries

### DIFF
--- a/docs/version-1.37/modules/en/partials/product-specific/quick-start-installation.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/quick-start-installation.adoc
@@ -1,0 +1,72 @@
+[IMPORTANT]
+.Authentication
+====
+
+{admc-short-name} component images are distributed through the
+https://apps.rancher.io[SUSE Application Collection]. You need credentials to
+access the registry. See the
+https://docs.apps.rancher.io/get-started/authentication/[Application Collection
+authentication documentation] for how to obtain them.
+
+Then log in to the registry with Helm:
+
+[subs="+attributes",console]
+----
+helm registry login dp.apps.rancher.io \
+  --username <your-username> \
+  --password <your-token>
+----
+
+====
+
+Deploy the {admc-short-name} stack using the `suse-security-admission-controller`
+Helm chart from the SUSE Application Collection.
+
+First, create the namespace and an image pull secret so the cluster can
+authenticate when pulling component images:
+
+[subs="+attributes",console]
+----
+kubectl create namespace {admc-namespace}
+----
+
+[subs="+attributes",console]
+----
+kubectl create secret docker-registry application-collection \
+  -n {admc-namespace} \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<your-username> \
+  --docker-password=<your-token>
+----
+
+The `suse-security-admission-controller` chart installs all {admc-short-name}
+components in a single Helm release:
+
+* The {cluster-admission-policy}, {admission-policy} and {policy-server}
+  Custom Resource Definitions, as well as the {policy-report} Custom Resource
+  Definitions used by the audit scanner.
+* The {admc-short-name} controller and the audit scanner.
++
+[NOTE]
+====
+
+If you need to disable the audit scanner component check the audit scanner
+installation xref:howtos/audit-scanner.adoc[documentation page].
+
+====
++
+* A `PolicyServer` resource named `default`. It can also install a set of
+  recommended policies to secure your cluster by enforcing well known best
+  practices.
+
+[subs="+attributes",console]
+----
+helm install {admc-release} \
+  {admc-chart-location} \
+  -n {admc-namespace} \
+  --set global.imagePullSecrets={application-collection}
+----
+
+The default configuration values are sufficient for most deployments. The
+https://docs.apps.rancher.io[SUSE Application Collection documentation] describes
+all the options.

--- a/docs/version-1.37/modules/en/partials/product-specific/quick-start-policyserver-note.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/quick-start-policyserver-note.adoc
@@ -1,0 +1,7 @@
+[NOTE]
+====
+
+Check the latest released `PolicyServer` version in the SUSE Application Collection and change
+the tag to match.
+
+====

--- a/docs/version-1.37/modules/en/partials/product-specific/variables.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/variables.adoc
@@ -1,0 +1,6 @@
+// This partial file contains variables that are relevant only for the product
+// version only
+
+// Default container image tag used in the documentation version. All the admission
+// controller container image has synced container tag
+:default-container-image-tag: 1.37.0


### PR DESCRIPTION
# Description

This adds the missing partials and variable configuration to adapt the quickstart documentation with the product documentation.

> [!WARNING]
> This PR requires a sync from the community repo to make it work properly