### PR TITLE
docs(migration): Appco migration docs

### DIFF
--- a/docs/version-1.37/modules/en/pages/product-specific/howtos/migration/app136-to-app137-migration.adoc
+++ b/docs/version-1.37/modules/en/pages/product-specific/howtos/migration/app136-to-app137-migration.adoc
@@ -1,0 +1,455 @@
+include::partial$variables.adoc[]
+
+:page-languages: [en, de, es, fr, ja, pt, zh]
+:revdate: 2026-07-16
+:page-revdate: {revdate}
+:description: Migrate from the SUSE Application Collection suse-security-admission-controller 0.8.0 umbrella chart (three subcharts) to the 1.0.0 flat single chart.
+:doc-persona: ["kubewarden-operator"]
+:doc-topic: ["chart-migration", "application-collection", "appco-upgrade"]
+:doc-type: ["howto"]
+:keywords: ["{admc-name}", "kubewarden", "helm", "chart", "migration", "upgrade", "suse-security-admission-controller", "application-collection", "appco", "subchart", "flat-chart"]
+:sidebar_label: Migrate from 1.36 three-subchart chart to 1.37
+:migration-namespace: $NAMESPACE
+:migration-backup-selector: -l app.kubernetes.io/name!=kubewarden-defaults
+
+= Migrate from {admc-name} 1.36 three-subchart chart to 1.37
+
+This page describes how to migrate an existing {admc-name} installation based
+on the `suse-security-admission-controller` version `0.8.0` Helm chart to the
+`suse-security-admission-controller` version `1.0.0` chart, both published in
+the https://apps.rancher.io[SUSE Application Collection].
+
+The version `0.8.0` chart is an umbrella chart that embeds three Kubewarden
+subcharts (`kubewarden-crds`, `kubewarden-controller`, and
+`kubewarden-defaults`) as Helm dependencies. Version `1.0.0` replaces this
+structure with a single flat chart that contains all {admc-product-short-name}
+components directly, removing the subchart nesting.
+
+[WARNING]
+====
+As described in the xref:reference/upgrade-path.adoc[upgrade path documentation],
+version jumping is not allowed. You must migrate from {admc-name} chart version
+`0.8.0` (appVersion `1.36.0`) to version `1.0.0` (appVersion `1.37.0`).
+====
+
+Unlike the
+xref:product-specific/howtos/chart-migration.adoc[migration from the community three-chart setup],
+this is an AppCo-to-AppCo migration. The image registry
+(`dp.apps.rancher.io`), the registry key (`global.imageRegistry`), and the pull
+secrets key (`global.imagePullSecrets`) all remain the same. The main work is
+flattening your values file by removing the subchart key prefixes.
+
+This migration involves a short window, between uninstalling the old chart and
+the new chart becoming ready, when policies do not protect your cluster. You
+can use the xref:howtos/audit-scanner.adoc[Audit Scanner] after the migration
+completes to identify any resources that may have entered the cluster without
+being evaluated during that window.
+
+[#what-changes]
+== What changes in this migration
+
+[cols="1,2,2", options="header"]
+|===
+| Aspect | Old chart (v0.8.0) | New chart (v1.0.0)
+
+| Chart version
+| `0.8.0` (appVersion `1.36.0`)
+| `1.0.0` (appVersion `1.37.0`)
+
+| Internal structure
+| Umbrella chart with three subcharts: `kubewarden-crds`, `kubewarden-controller`, `kubewarden-defaults`
+| All Kubewarden components in one flat chart; no Kubewarden subcharts
+
+| Helm releases
+| One release managing three subcharts
+| One release, one flat chart
+
+| Values shape
+| Subchart keys required: `kubewarden-controller.*`, `kubewarden-defaults.*`, `kubewarden-crds.*`
+| All keys at top level; subchart key prefixes removed
+
+| Image registry
+| `dp.apps.rancher.io`
+| `dp.apps.rancher.io` (unchanged)
+
+| Registry key
+| `global.imageRegistry`
+| `global.imageRegistry` (unchanged)
+
+| Pull secrets key
+| `global.imagePullSecrets`
+| `global.imagePullSecrets` (unchanged)
+
+| Policy module registry
+| `ghcr.io` (via `recommendedPolicies.defaultPoliciesRegistry`)
+| `ghcr.io` (unchanged)
+
+| CRD ownership
+| `kubewarden-crds` subchart, with no `helm.sh/resource-policy: keep` annotation
+| Flat chart CRDs annotated with `helm.sh/resource-policy: keep`
+|===
+
+[NOTE]
+====
+Because this is an AppCo-to-AppCo migration, you do not need to change
+`global.imageRegistry`, `global.imagePullSecrets`, or your Application
+Collection registry credentials. Those values carry over unchanged. The only
+structural change is removing the subchart key prefixes from your values.
+====
+
+[WARNING]
+====
+The `kubewarden-crds` subchart embedded in the v0.8.0 chart does not annotate
+its CRDs with `helm.sh/resource-policy: keep`. Uninstalling the v0.8.0 chart
+deletes the five policy CRDs
+(`policyservers.policies.kubewarden.io`,
+`clusteradmissionpolicies.policies.kubewarden.io`,
+`admissionpolicies.policies.kubewarden.io`,
+`clusteradmissionpolicygroups.policies.kubewarden.io`,
+`admissionpolicygroups.policies.kubewarden.io`), which cascade-deletes every
+custom resource of those types from the cluster.
+
+The `kubewarden-controller` subchart also runs a pre-delete hook on uninstall
+that deletes all PolicyServer resources before the controller itself is removed.
+
+Nothing policy-related survives the uninstall. The backup taken in Step 1 is
+the only copy of your policies and policy server definitions. Step 6 restores
+them after the new chart is running.
+====
+
+[#prerequisites]
+== Prerequisites
+
+* Helm v3 or later.
+* `kubectl` with access to your cluster.
+* `yq` v4 (https://github.com/mikefarah/yq[github.com/mikefarah/yq]) for
+  filtering backed-up resources and transforming your values file.
+* The {admc-name} chart installed at chart version `0.8.0` (appVersion `1.36.0`).
+* Valid credentials for `dp.apps.rancher.io` (already configured from your
+  existing installation).
+* The {admc-name} chart version `1.0.0` available at
+  `{admc-chart-location}`.
+
+[#migration-steps]
+== Migration steps
+
+Set shell variables used throughout the following steps.
+Replace the placeholders with values matching your installation:
+
+[source,sh]
+----
+NAMESPACE=<your-namespace>
+----
+
+`$NAMESPACE` is the namespace where the {admc-name} chart is installed.
+
+[#step-backup]
+=== Step 1: Back up your policies and policy servers
+
+Back up all your {policy-server} instances and policy custom resources.
+The backup is the only copy — the uninstall in Step 3 deletes everything (see
+that step's warning).
+
+[NOTE]
+====
+Resources managed by the v0.8.0 chart's `kubewarden-defaults` subchart — the
+default `PolicyServer` and the recommended `ClusterAdmissionPolicies` — are
+excluded from the backup using a label selector. The v1.0.0 chart recreates them
+on install (via its `kubewarden-defaults` ConfigMap) when `policyServer.enabled`
+or `recommendedPolicies.enabled` is set, so restoring the backed-up copies would
+collide with the chart-managed ones that already exist.
+
+The selector uses the chart-name label (`app.kubernetes.io/name=kubewarden-defaults`),
+which identifies subchart-managed resources. In the 0.8.0 umbrella the
+`app.kubernetes.io/instance` label carries the umbrella release name, not
+`kubewarden-defaults`, so the filter keys on the name label only.
+====
+
+include::partial$backup-policies.adoc[]
+
+[#step-capture-values]
+=== Step 2: Capture your existing values
+
+Save your current user-supplied values from the existing release for reference.
+You will transform this file in Step 4.
+
+[source,sh]
+----
+helm get values suse-security-admission-controller \
+  -n "$NAMESPACE" \
+  -o yaml > old-values.yaml
+----
+
+[#step-uninstall]
+=== Step 3: Uninstall the old chart
+
+Uninstall the v0.8.0 chart. Because there is a single Helm release, only one
+command is needed:
+
+[source,sh]
+----
+helm uninstall suse-security-admission-controller -n "$NAMESPACE"
+----
+
+[WARNING]
+====
+As noted in <<what-changes>>, uninstalling the v0.8.0 chart deletes the five
+policy CRDs and cascade-deletes every policy custom resource. The
+`kubewarden-controller` subchart pre-delete hook also deletes all PolicyServer
+resources before the controller pod is removed.
+
+Nothing policy-related survives the uninstall. The backup taken in Step 1 is
+the only copy.
+====
+
+[#step-flatten-values]
+=== Step 4: Flatten your values file
+
+The central change between v0.8.0 and v1.0.0 is that subchart key prefixes are
+removed. Every key previously nested under `kubewarden-controller`,
+`kubewarden-defaults`, or `kubewarden-crds` is now at the top level.
+
+Use the following `yq` command to promote all subchart keys automatically:
+
+[source,sh]
+----
+yq eval '
+  . * (.["kubewarden-controller"] // {}) |
+  . * (.["kubewarden-defaults"] // {}) |
+  . * (.["kubewarden-crds"] // {}) |
+  del(.["kubewarden-controller"]) |
+  del(.["kubewarden-defaults"]) |
+  del(.["kubewarden-crds"])
+' old-values.yaml > new-values.yaml
+----
+
+The transformation converts a v0.8.0 values file like this:
+
+[source,yaml]
+----
+global:
+  imagePullSecrets:
+    - application-collection
+kubewarden-controller:
+  auditScanner:
+    policyReporter: true
+  policy-reporter:
+    ui:
+      service:
+        type: NodePort
+kubewarden-defaults:
+  recommendedPolicies:
+    enabled: true
+----
+
+Into the flat v1.0.0 form:
+
+[source,yaml]
+----
+global:
+  imagePullSecrets:
+    - application-collection
+auditScanner:
+  policyReporter: true
+policy-reporter:
+  ui:
+    service:
+      type: NodePort
+recommendedPolicies:
+  enabled: true
+----
+
+Then strip `policyServer.imagePullSecret` if it flattened to `null`. The
+v0.8.0 `kubewarden-defaults` subchart defaults that key to `null`, so if you
+seeded your override file from the chart's default `values.yaml`, the flatten
+promotes it rather than dropping it. The v1.0.0 chart expects the key to be
+absent or set to `""`:
+
+[source,sh]
+----
+yq eval 'del(select(.policyServer.imagePullSecret == null) | .policyServer.imagePullSecret)' \
+  -i new-values.yaml
+----
+
+This command is a no-op if `policyServer.imagePullSecret` is absent or holds a
+real value, so it is safe to run regardless.
+
+After running the `yq` commands, review `new-values.yaml` manually before
+proceeding. Pay attention to:
+
+* **`policyServer.imagePullSecret`**: the v0.8.0 subchart defaults this to
+  `null`. If your override file was seeded from the chart's default
+  `values.yaml`, that `null` ends up in `new-values.yaml` after flattening.
+  The cleanup command above strips it. If you set the key to a real secret
+  name, the command leaves it alone.
+* **`kubewarden-controller.fullnameOverride`**: if you had set
+  `kubewarden-controller.fullnameOverride: suse-security-admission-controller`,
+  the `yq` command promotes it to `fullnameOverride` at the top level. Verify
+  this is what you intend.
+
+See <<mapping-values>> for the complete key mapping reference.
+
+[#step-install]
+=== Step 5: Install the new chart
+
+Install the v1.0.0 chart using the flattened values file produced in Step 4.
+The chart ships its own CRDs and installs them directly, so no ownership
+adoption is needed.
+
+[source,sh,subs="attributes+"]
+----
+helm install suse-security-admission-controller \
+  {admc-chart-location} \
+  --version 1.0.0 \
+  -n "$NAMESPACE" \
+  --values new-values.yaml \
+  --wait
+----
+
+[#step-restore]
+=== Step 6: Restore your policies and policy servers
+
+The `--wait` flag in Step 5 only blocks until the Helm-managed workloads are
+ready, like the controller Deployment. It does not wait for the default
+{policy-server}, because the controller (not Helm) creates that from the
+`kubewarden-defaults` ConfigMap once the install finishes. It appears a moment
+after `helm install` returns. The PolicyServers you restore below are handled
+the same way: the controller reconciles each one and starts its Deployment and
+webhook. So don't be surprised if a policy shows `pending` right after you
+apply the backup. It moves to `active` on its own once the controller finishes
+reconciling.
+
+Update the PolicyServer images in your backup
+file before applying. The backed-up PolicyServers carry a `spec.image` field
+pinned to the v0.8.0 policy-server image. Update it to the v1.0.0 image:
+
+[source,sh,subs="attributes+"]
+----
+yq eval '.items[].spec.image = "{default-policy-server-image-tag}"' \
+  -i policyservers-backup.yaml
+----
+
+Now restore the backed-up resources. Use `kubectl create` rather than
+`kubectl apply`: the default `PolicyServer` and recommended
+`ClusterAdmissionPolicies` were excluded from the backup in Step 1 and are
+already present in the cluster (recreated by the new chart). `kubectl create`
+makes the intent explicit — these are new user resources, not updates to
+existing ones.
+
+[source,sh]
+----
+kubectl create -f policyservers-backup.yaml
+kubectl create -f clusteradmissionpolicies-backup.yaml
+kubectl create -f admissionpolicies-backup.yaml
+kubectl create -f clusteradmissionpolicygroups-backup.yaml
+kubectl create -f admissionpolicygroups-backup.yaml
+----
+
+[#step-verify]
+=== Step 7: Verify the migration
+
+include::partial$verify-migration.adoc[]
+
+[#mapping-values]
+== Mapping your values to the new chart
+
+The v1.0.0 chart uses a flat `values.yaml` that consolidates what the three
+subcharts configured through nested keys. The rule is straightforward: strip
+the subchart prefix. The key names themselves do not change.
+
+`global.*` keys pass through unchanged, they already sit at the top level in
+both charts.
+
+For everything else, drop the subchart parent key and keep the rest of the key
+path exactly as it was:
+
+[source,text]
+----
+kubewarden-crds.<key>        ->  <key>
+kubewarden-controller.<key>  ->  <key>
+kubewarden-defaults.<key>    ->  <key>
+----
+
+For example, `kubewarden-controller.auditScanner.policyReporter` becomes
+`auditScanner.policyReporter`, and `kubewarden-defaults.recommendedPolicies.enabled`
+becomes `recommendedPolicies.enabled`. This is exactly what the `yq` command in
+Step 4 does automatically. `policy-reporter` stays a subchart in v1.0.0, so
+`kubewarden-controller.policy-reporter.*` becomes `policy-reporter.*`.
+
+A few keys need attention beyond stripping the prefix:
+
+[cols="2,3", options="header"]
+|===
+| Key (after stripping the prefix) | Note
+
+| `fullnameOverride`
+| Promoted from `kubewarden-controller.fullnameOverride`. Verify the value still
+matches your deployment; it controls the name prefix of controller resources.
+
+| `policyServer.imagePullSecret`
+| The v0.8.0 `kubewarden-defaults` subchart defaults this to `null`. The Step 4
+cleanup command removes it if it flattened to `null`.
+
+| `additionalLabels`, `additionalAnnotations`
+| Set in both `kubewarden-controller` and `kubewarden-defaults`. The Step 4 merge
+applies them left-to-right, so `kubewarden-defaults` values win. Review the merged
+output and set the final value explicitly if needed.
+|===
+
+[#caveats]
+== Caveats
+
+[#crd-adoption]
+=== CRDs are recreated by the new chart
+
+The `kubewarden-crds` subchart embedded in v0.8.0 does not annotate its CRDs
+with `helm.sh/resource-policy: keep`, so `helm uninstall` in Step 3 deletes
+them. The v1.0.0 chart ships its own copies of the five policy CRDs and
+installs them as part of a fresh install. No ownership adoption is required.
+
+The v1.0.0 chart does annotate its CRDs with `helm.sh/resource-policy: keep`,
+so a future uninstall of the v1.0.0 chart will leave the CRDs in place to
+protect any policies still running in the cluster.
+
+[#fullname-override]
+=== `fullnameOverride` after flattening
+
+The v0.8.0 `values.local.yaml` example sets
+`kubewarden-controller.fullnameOverride: suse-security-admission-controller`.
+After flattening, this becomes top-level `fullnameOverride`. Verify that the
+promoted value matches what you need for your deployment; it controls the name
+prefix of controller resources such as the deployment and services.
+
+[#downtime-window]
+=== Policy enforcement gap
+
+Between Step 3 (uninstall the old chart) and Step 5 (the new chart becoming
+ready), no admission controller is running. The webhook configurations created
+by the old chart are deleted when the controller subchart is uninstalled, so
+no admission evaluation takes place during this window.
+
+After the migration completes, run the Audit Scanner to identify any
+non-compliant resources that may have entered the cluster during the gap:
+
+[source,sh]
+----
+kubectl create job --from=cronjob/audit-scanner audit-scanner-manual -n "$NAMESPACE"
+----
+
+[#image-pull-secrets]
+=== Image pull secrets for policy-server pods
+
+Because this is an AppCo-to-AppCo migration, your existing `global.imagePullSecrets`
+value and the `application-collection` secret carry over unchanged into the new chart.
+
+include::partial$image-pull-secrets-caveat.adoc[]
+
+[#pull-secret-null]
+=== `policyServer.imagePullSecret` type change
+
+The v0.8.0 `kubewarden-defaults` subchart defaults `policyServer.imagePullSecret`
+to `null`; the v1.0.0 chart defaults it to `""` (empty string). If you seeded
+your override file from the chart's default `values.yaml`, the flatten in Step 4
+picks up that `null` and puts it at the top level of `new-values.yaml`. The
+cleanup command in Step 4 strips it. If you set this key to a real secret name,
+the command leaves it alone and there is nothing else to do.

--- a/docs/version-1.37/modules/en/pages/product-specific/howtos/migration/community136-to-appco137-migration.adoc
+++ b/docs/version-1.37/modules/en/pages/product-specific/howtos/migration/community136-to-appco137-migration.adoc
@@ -1,0 +1,431 @@
+include::partial$variables.adoc[]
+
+:page-languages: [en, de, es, fr, ja, pt, zh]
+:revdate: 2026-07-08
+:page-revdate: {revdate}
+:description: Migrate from the community kubewarden-crds, kubewarden-controller, and kubewarden-defaults Helm charts to the SUSE Application Collection suse-security-admission-controller single chart.
+:doc-persona: ["kubewarden-operator"]
+:doc-topic: ["chart-migration", "application-collection"]
+:doc-type: ["howto"]
+:keywords: ["{admc-name}", "kubewarden", "helm", "chart", "migration", "upgrade", "kubewarden-crds", "kubewarden-controller", "kubewarden-defaults", "suse-security-admission-controller", "application-collection", "appco"]
+:sidebar_label: Migrate from Kubewarden 1.36 three-chart setup to {admc-name} 1.37
+:migration-namespace: $TARGET_NAMESPACE
+:migration-backup-selector: -l app.kubernetes.io/instance!=kubewarden-defaults -l app.kubernetes.io/name!=kubewarden-defaults
+
+= Migrate from {admc-community-name} 1.36 three-chart setup to {admc-name} 1.37
+
+This page describes how to migrate an existing {community-project-name} installation
+based on the community upstream Helm charts to the {admc-name} single Helm chart,
+published in the https://apps.rancher.io[SUSE Application Collection].
+
+If you are running the legacy community three-chart setup (`kubewarden-crds`,
+`kubewarden-controller`, `kubewarden-defaults`, from `charts.kubewarden.io`),
+this page guides you through the steps to reach a single {admc-name} Helm release
+(`suse-security-admission-controller`, from
+`oci://dp.apps.rancher.io/charts/suse-security-admission-controller`).
+
+[WARNING]
+====
+As described in the xref:reference/upgrade-path.adoc[upgrade path documentation],
+version jumping is not allowed. You must migrate from {community-project-name}
+v1.36 to {admc-name} v1.37.
+====
+
+This migration involves a short window, between uninstalling the old charts and
+the new chart becoming ready, when policies do not protect your cluster.
+
+You can use the
+xref:howtos/audit-scanner.adoc[Audit Scanner]
+after the migration completes to identify any resources that may have entered the
+cluster without being evaluated during that window.
+
+[#what-changes]
+== What changes in this migration
+
+This is a cross-vendor migration. Beyond the chart consolidation (three charts
+to one), the {admc-name} chart uses different conventions for image registries
+and pull secrets compared to the community charts.
+
+[cols="1,2,2", options="header"]
+|===
+| Aspect | Community charts (source) | {admc-name} chart (target)
+
+| Helm releases
+| Three independent releases: `kubewarden-crds`, `kubewarden-controller`, `kubewarden-defaults`
+| One release: `suse-security-admission-controller`
+
+| Chart source
+| `https://charts.kubewarden.io`
+| `oci://dp.apps.rancher.io/charts/suse-security-admission-controller`
+
+| Image registry key
+| `global.cattle.systemDefaultRegistry` (default: `ghcr.io`)
+| `global.imageRegistry` (default: `dp.apps.rancher.io`)
+
+| Pull secrets key
+| `global.cattle.imagePullSecrets`
+| `global.imagePullSecrets`
+
+| Component images
+| `ghcr.io/kubewarden/adm-controller/controller`, `ghcr.io/kubewarden/adm-controller/audit-scanner`, `ghcr.io/kubewarden/adm-controller/policy-server`
+| `dp.apps.rancher.io/containers/kubewarden-controller`, `dp.apps.rancher.io/containers/kubewarden-audit-scanner`, `dp.apps.rancher.io/containers/kubewarden-policy-server`
+
+| Policy module registry
+| `ghcr.io` (set via `recommendedPolicies.defaultPoliciesRegistry`)
+| `ghcr.io` (unchanged)
+
+| Values shape
+| Three separate files, one per chart
+| One flat file covering all components
+|===
+
+[IMPORTANT]
+====
+The {admc-name} chart does not read `global.cattle.systemDefaultRegistry` or
+`global.cattle.imagePullSecrets`. Those keys have no effect and must not be
+carried into the new chart. Use `global.imageRegistry` and
+`global.imagePullSecrets` instead, or rely on the chart defaults to pull from
+`dp.apps.rancher.io`.
+
+Note that the {admc-name} chart also reads a top-level `imagePullSecrets` list
+(with `global.imagePullSecrets` taking precedence). If you carry an
+`imagePullSecrets` key from the community values, use `global.imagePullSecrets`
+to keep the values in the preferred location.
+====
+
+[IMPORTANT]
+====
+Backed-up PolicyServer resources contain an explicit `spec.image` field pinned
+to the community policy-server image (for example,
+`ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0`). The migration
+process in <<step-restore>> updates this field to the {admc-name} image
+(`{default-policy-server-image-tag}`) before applying the backup.
+
+Note that policy `spec.module` references (the Wasm policy module OCI images,
+e.g. `ghcr.io/kubewarden/policies/...`) are for now served from `ghcr.io` in both
+the community and {admc-name} charts and do *not* need to be changed.
+====
+
+[#prerequisites]
+== Prerequisites
+
+* Helm v3 or later.
+* `kubectl` with access to your cluster.
+* `yq` v4 (https://github.com/mikefarah/yq[github.com/mikefarah/yq]) for
+  filtering backed-up resources.
+* An access token or service account for the SUSE Application Collection. See
+  the https://docs.apps.rancher.io/get-started/authentication/[Application
+  Collection authentication documentation] for how to obtain credentials.
+* The three community charts installed in your cluster, all at
+  appVersion `v1.36.0`.
+* The {admc-name} chart available at appVersion `1.37.0` (from
+  `oci://dp.apps.rancher.io/charts/suse-security-admission-controller`).
+
+[#migration-steps]
+== Migration steps
+
+Set shell variables for the namespaces used throughout the following steps.
+The community charts and the {admc-name} chart typically live in different
+namespaces, so they each get their own variable. Replace the placeholders
+with the actual namespaces from your installation:
+
+[source,sh]
+----
+SOURCE_NAMESPACE=<community-namespace>   # e.g. kubewarden
+TARGET_NAMESPACE=<appco-namespace>       # e.g. suse-sec-adm-controller
+----
+
+`$SOURCE_NAMESPACE` is the namespace where the three community charts are
+installed. `$TARGET_NAMESPACE` is the namespace where the {admc-name} chart
+will be installed.
+
+[#step-backup]
+=== Step 1: Back up your policies and policy servers
+
+Back up all your {policy-server} instances and policy custom resources.
+These are restored after the new chart is running.
+
+[NOTE]
+====
+Resources managed by the community `kubewarden-defaults` chart — the default
+`PolicyServer` and the recommended `ClusterAdmissionPolicies` — are excluded
+from the backup using a label selector. The {admc-name} chart recreates them on
+install when `recommendedPolicies.enabled` is set, so restoring the backed-up
+copies would collide with the chart-managed ones that already exist.
+====
+
+include::partial$backup-policies.adoc[]
+
+[#step-capture-values]
+=== Step 2: Capture your existing values (optional)
+
+Save your current user-supplied values from each community release for reference.
+You will pass these files directly to the new chart in Step 6.
+
+[source,sh]
+----
+helm get values kubewarden-crds -n "$SOURCE_NAMESPACE" -o yaml > kubewarden-crds-values.yaml
+helm get values kubewarden-controller -n "$SOURCE_NAMESPACE" -o yaml > kubewarden-controller-values.yaml
+helm get values kubewarden-defaults -n "$SOURCE_NAMESPACE" -o yaml > kubewarden-defaults-values.yaml
+----
+
+Review the captured values and identify settings you want to carry over to the
+{admc-name} chart. Pay special attention to these critical key changes:
+
+* **`global.cattle.imagePullSecrets`** must be renamed to **`global.imagePullSecrets`**
+* **`global.cattle.systemDefaultRegistry`** is not recognized by the {admc-name} chart.
+  Remove it and use `global.imageRegistry` instead, or omit it to use the chart
+  default (`dp.apps.rancher.io`)
+
+See <<mapping-values>> for the complete mapping between community and {admc-name}
+chart values.
+
+[#step-uninstall]
+=== Step 3: Uninstall the community charts
+
+Uninstall the three community charts in order.
+
+[source,sh]
+----
+helm uninstall kubewarden-defaults -n "$SOURCE_NAMESPACE" --wait
+helm uninstall kubewarden-controller -n "$SOURCE_NAMESPACE" --wait
+helm uninstall kubewarden-crds -n "$SOURCE_NAMESPACE" --wait
+----
+
+[WARNING]
+====
+The community `kubewarden-crds` chart does not annotate its CRDs with
+`helm.sh/resource-policy: keep`. Uninstalling it deletes the five policy
+CRDs (`policyservers.policies.kubewarden.io`,
+`clusteradmissionpolicies.policies.kubewarden.io`,
+`admissionpolicies.policies.kubewarden.io`,
+`clusteradmissionpolicygroups.policies.kubewarden.io`,
+`admissionpolicygroups.policies.kubewarden.io`), which cascade-deletes every
+custom resource of those types from the cluster.
+
+The community `kubewarden-controller` chart also runs a pre-delete hook on
+uninstall that deletes all PolicyServer resources before the controller itself
+is removed.
+
+Nothing policy-related survives the uninstall. The backup taken in Step 1 is
+the only copy of your policies and policy server definitions. Step 7 restores
+them after the new chart is running.
+====
+
+[#step-registry-login]
+=== Step 4: Log in to the Application Collection registry
+
+[source,sh]
+----
+helm registry login dp.apps.rancher.io \
+  --username <your-username> \
+  --password <your-token>
+----
+
+[#step-pull-secret]
+=== Step 5: Create the image pull secret
+
+include::partial$create-image-pull-secret.adoc[]
+
+[#step-install]
+=== Step 6: Install the {admc-name} single chart
+
+The community uninstall in Step 3 deletes the five policy CRDs and all their
+custom resources. The {admc-name} chart ships its own CRDs and installs them
+into a clean cluster, so no ownership adoption is needed.
+
+The `--set global.imagePullSecrets={application-collection}` flag passes
+the pull secret created in the previous step so the cluster can pull the
+component images.
+
+[source,sh]
+----
+helm install kubewarden \
+  oci://dp.apps.rancher.io/charts/suse-security-admission-controller \
+  -n "$TARGET_NAMESPACE" \
+  --set global.imagePullSecrets={application-collection}
+----
+
+If you have values to carry over from the community charts, pass the per-chart
+value files you saved in Step 2 using multiple `--values` flags (see
+<<mapping-values>> for key differences). Helm merges them left-to-right, so
+later files take precedence:
+
+[source,sh]
+----
+helm install kubewarden \
+  oci://dp.apps.rancher.io/charts/suse-security-admission-controller \
+  -n "$TARGET_NAMESPACE" \
+  --set global.imagePullSecrets={application-collection} \
+  --values kubewarden-crds-values.yaml \
+  --values kubewarden-controller-values.yaml \
+  --values kubewarden-defaults-values.yaml
+----
+
+[#step-restore]
+=== Step 7: Restore your policies and policy servers
+
+Before restoring resources, wait for the controller to be fully ready. The
+restored resources are evaluated by the admission webhooks that the new
+controller registers, so the controller must be running before you apply them:
+
+[source,sh]
+----
+kubectl rollout status deployment \
+  -n "$TARGET_NAMESPACE" \
+  -l app.kubernetes.io/component=controller \
+  --timeout=300s
+----
+
+Once the controller is ready, update the PolicyServer images in your backup file
+before applying. The backed-up PolicyServers carry a `spec.image` field pinned
+to the community policy-server image. Update it to the {admc-name} image:
+
+[source,sh,subs="attributes+"]
+----
+yq eval '.items[].spec.image = "{default-policy-server-image-tag}"' \
+  -i policyservers-backup.yaml
+----
+
+Now restore the backed-up resources. Use `kubectl create` rather than
+`kubectl apply`: the default `PolicyServer` and recommended
+`ClusterAdmissionPolicies` were excluded from the backup in Step 1 and are
+already present in the cluster (recreated by the new chart). `kubectl create`
+makes the intent explicit — these are new user resources, not updates to
+existing ones.
+
+[source,sh]
+----
+kubectl create -f policyservers-backup.yaml
+kubectl create -f clusteradmissionpolicies-backup.yaml
+kubectl create -f admissionpolicies-backup.yaml
+kubectl create -f clusteradmissionpolicygroups-backup.yaml
+kubectl create -f admissionpolicygroups-backup.yaml
+----
+
+[#step-verify]
+=== Step 8: Verify the migration
+
+include::partial$verify-migration.adoc[]
+
+[#mapping-values]
+== Mapping your community chart values to the {admc-name} chart
+
+The {admc-name} chart uses a single flat `values.yaml` that covers what the
+three community charts (`kubewarden-crds`, `kubewarden-controller`,
+`kubewarden-defaults`) configured through three separate files. Each community
+chart already keeps its values at the top level of its own `values.yaml`;
+migrating means consolidating three separate files into one, with key names
+unchanged. There are no key-namespace prefixes to add or remove.
+
+[NOTE]
+====
+If you are familiar with a previous AppCo umbrella chart that used the community
+charts as subcharts, you may remember values being nested under key namespaces
+such as `kubewarden-crds.*`, `kubewarden-controller.*`, and
+`kubewarden-defaults.*`. That nesting was specific to that umbrella chart and
+does not apply to this migration. The community charts this page covers have
+always used flat, top-level values.
+====
+
+=== Image registry and pull secrets
+
+The registry convention changes. The community charts used
+`global.cattle.systemDefaultRegistry` (a Rancher-specific key).
+The {admc-name} chart uses `global.imageRegistry`, the standard Application
+Collection key.
+
+Do not carry `global.cattle.*` keys into the {admc-name} chart values. The chart
+ignores them.
+
+If you pull images from the default Application Collection registry
+(`dp.apps.rancher.io`), you do not need a registry override.
+
+If you pull images from a private mirror or an air-gapped registry:
+
+[source,yaml]
+----
+global:
+  imageRegistry: "my-private-registry.example.com"
+  imagePullSecrets:
+    - name: my-pull-secret
+----
+
+For pull secrets, the {admc-name} chart reads `global.imagePullSecrets` (a list
+of secret name strings or `{name: ...}` objects). This replaces
+`global.cattle.imagePullSecrets` from the community charts. The chart also
+reads a top-level `imagePullSecrets` list, with `global.imagePullSecrets`
+taking precedence when both are set, so place your secrets under
+`global.imagePullSecrets`.
+
+=== Policy module registry
+
+The `recommendedPolicies.defaultPoliciesRegistry` value defaults to `ghcr.io`
+in both charts. The policy module image repositories
+(`kubewarden/policies/allow-privilege-escalation-psp`, etc.) are also identical.
+If you did not override `defaultPoliciesRegistry` in the community setup, no
+change is needed.
+
+In the community charts, `recommendedPolicies.defaultPoliciesRegistry` defaults
+to `""`, which falls back to `global.cattle.systemDefaultRegistry` (`ghcr.io`).
+The {admc-name} chart has no such fallback; it only honors
+`recommendedPolicies.defaultPoliciesRegistry` directly.
+
+If you relied on `global.cattle.systemDefaultRegistry` to redirect policy
+module pulls to a private mirror, you must now set
+`recommendedPolicies.defaultPoliciesRegistry` explicitly in the {admc-name}
+chart values:
+
+[source,yaml]
+----
+recommendedPolicies:
+  defaultPoliciesRegistry: "my-private-registry.example.com"
+----
+
+=== CRD toggles
+
+The two CRD installation toggles use the same top-level key names in the
+community `kubewarden-crds` chart and the {admc-name} chart:
+
+* `installOpenReportsCRDs`
+* `installPolicyReportCRDs`
+
+If you set either of these in your community `kubewarden-crds` values, carry
+the same top-level key into the {admc-name} values file unchanged.
+
+[#caveats]
+== Caveats
+
+[#crd-adoption]
+=== CRDs are recreated by the new chart
+
+The community `kubewarden-crds` chart does not annotate its CRDs with
+`helm.sh/resource-policy: keep`, so `helm uninstall kubewarden-crds` deletes
+them. The {admc-name} chart ships its own copies of the five policy CRDs and
+installs them as part of a fresh install. No ownership adoption is required.
+
+Note that the {admc-name} chart does annotate its CRDs with
+`helm.sh/resource-policy: keep`, so a future uninstall of the {admc-name}
+chart will leave the CRDs in place to protect any policies still running in
+the cluster.
+
+[#image-pull-secrets]
+=== Image pull secrets for controller and policy-server images
+
+include::partial$image-pull-secrets-caveat.adoc[]
+
+[#downtime-window]
+=== Policy enforcement gap
+
+Between step 3 (uninstall the community charts) and step 6 (the {admc-name}
+chart becoming ready), no admission controller is running. The webhook
+configurations created by the old charts are deleted when the controller chart is
+uninstalled, so no admission evaluation takes place during this window.
+
+After the migration completes, run the Audit Scanner to identify any
+non-compliant resources that may have entered the cluster during the gap:
+
+[source,sh]
+----
+kubectl create job --from=cronjob/audit-scanner audit-scanner-manual -n "$TARGET_NAMESPACE"
+----

--- a/docs/version-1.37/modules/en/pages/product-specific/howtos/migration/community137-to-appco137-migration.adoc
+++ b/docs/version-1.37/modules/en/pages/product-specific/howtos/migration/community137-to-appco137-migration.adoc
@@ -1,0 +1,453 @@
+include::partial$variables.adoc[]
+
+:page-languages: [en, de, es, fr, ja, pt, zh]
+:revdate: 2026-07-16
+:page-revdate: {revdate}
+:description: Migrate from the community admission-controller Helm chart to the SUSE Application Collection suse-security-admission-controller single chart.
+:doc-persona: ["kubewarden-operator"]
+:doc-topic: ["chart-migration", "application-collection"]
+:doc-type: ["howto"]
+:keywords: ["{admc-name}", "kubewarden", "helm", "chart", "migration", "upgrade", "admission-controller", "suse-security-admission-controller", "application-collection", "appco", "single-chart"]
+:sidebar_label: Migrate from Kubewarden 1.37 single chart to {admc-name} 1.37
+:migration-namespace: $NAMESPACE
+:migration-backup-selector:
+
+= Migrate from {admc-community-name} 1.37 single chart to {admc-name} 1.37
+
+This page describes how to migrate an existing {community-project-name}
+installation based on the community `admission-controller` Helm chart
+(from `https://charts.kubewarden.io`) to the {admc-name}
+`suse-security-admission-controller` chart published in the
+https://apps.rancher.io[SUSE Application Collection].
+
+Both charts are single flat charts at appVersion `1.37`, so there is no value
+reshaping. The main work is updating the image registry and pull-secret
+conventions to match the {admc-name} chart, and adopting the surviving CRDs
+into the new Helm release. Because both charts keep CRDs and preserve user
+policies on uninstall, this is largely an in-place migration in the same
+namespace.
+
+[WARNING]
+====
+As described in the xref:reference/upgrade-path.adoc[upgrade path documentation],
+version jumping is not allowed. You must be running the community
+`admission-controller` chart at appVersion `v1.37.0` before migrating to
+{admc-name} appVersion `1.37.0`.
+====
+
+This migration involves a short window, between uninstalling the community
+chart and the {admc-name} chart becoming ready, when policies do not protect
+your cluster.
+
+You can use the xref:howtos/audit-scanner.adoc[Audit Scanner] after the
+migration completes to identify any resources that may have entered the cluster
+without being evaluated during that window.
+
+[#what-changes]
+== What changes in this migration
+
+Both charts are flat and share the same top-level key names, so only the image
+registry and pull-secret conventions differ.
+
+[cols="1,2,2", options="header"]
+|===
+| Aspect | Community chart (source) | {admc-name} chart (target)
+
+| Chart source
+| `admission-controller` from `https://charts.kubewarden.io`
+| `suse-security-admission-controller` from `{admc-chart-location}`
+
+| Image registry key
+| `global.cattle.systemDefaultRegistry` (default: `ghcr.io`)
+| `global.imageRegistry` (default: `dp.apps.rancher.io`)
+
+| Pull secrets key
+| `imagePullSecrets` (top-level list)
+| `global.imagePullSecrets`
+
+| Component images
+| `ghcr.io/kubewarden/adm-controller/controller`, `ghcr.io/kubewarden/adm-controller/audit-scanner`, `ghcr.io/kubewarden/adm-controller/policy-server`
+| `dp.apps.rancher.io/containers/kubewarden-controller`, `dp.apps.rancher.io/containers/kubewarden-audit-scanner`, `dp.apps.rancher.io/containers/kubewarden-policy-server`
+
+| Policy module registry
+| `ghcr.io` (via `recommendedPolicies.defaultPoliciesRegistry` or fallback)
+| `ghcr.io` (unchanged)
+
+| Values shape
+| Flat, top-level keys
+| Flat, identical key names
+
+| CRDs on uninstall
+| Kept (`helm.sh/resource-policy: keep`)
+| Kept (`helm.sh/resource-policy: keep`)
+
+| User policies on uninstall
+| Preserved by the cleanup hook
+| Preserved by the cleanup hook
+|===
+
+[IMPORTANT]
+====
+The {admc-name} chart does not read `global.cattle.systemDefaultRegistry` or
+`global.cattle.imagePullSecrets`. Remove those keys from your values; the chart
+ignores them entirely.
+
+For pull secrets, the {admc-name} chart reads both `global.imagePullSecrets`
+and a top-level `imagePullSecrets` list (with `global.imagePullSecrets` taking
+precedence when both are set). Use `global.imagePullSecrets`. The Step 3 `yq`
+transform moves the community top-level key there automatically.
+====
+
+[IMPORTANT]
+====
+PolicyServer resources may carry an explicit `spec.image` field pinned to the
+community policy-server image (for example,
+`ghcr.io/kubewarden/adm-controller/policy-server:v1.37.0`). The migration
+process in <<step-restore>> updates this field to the {admc-name} image
+(`{default-policy-server-image-tag}`) for any PolicyServer that has it set.
+
+Policy `spec.module` references (Wasm policy module OCI images,
+e.g. `ghcr.io/kubewarden/policies/...`) are served from `ghcr.io` in both
+charts and do *not* need to be changed.
+====
+
+[NOTE]
+====
+Because the community chart keeps its CRDs and preserves user-defined
+PolicyServers and policies on uninstall, the migration is largely in place: the
+{admc-name} chart adopts the surviving CRDs using `--take-ownership` rather
+than recreating them from scratch. See <<crd-adoption>> for details.
+====
+
+[#prerequisites]
+== Prerequisites
+
+* Helm v3.18 or later (required for `--take-ownership`).
+* `kubectl` with access to your cluster.
+* `yq` v4 (https://github.com/mikefarah/yq[github.com/mikefarah/yq]) for
+  filtering backed-up resources and transforming your values file.
+* An access token or service account for the SUSE Application Collection. See
+  the https://docs.apps.rancher.io/get-started/authentication/[Application
+  Collection authentication documentation] for how to obtain credentials.
+* The community `admission-controller` chart installed at appVersion `v1.37.0`.
+* The {admc-name} chart version `1.0.0` available at
+  `{admc-chart-location}`.
+
+[#migration-steps]
+== Migration steps
+
+Set a shell variable for the namespace where the community chart is installed.
+The {admc-name} chart is installed into the same namespace. Replace
+`<your-namespace>` with the actual namespace from your installation:
+
+[source,sh]
+----
+NAMESPACE=<your-namespace>
+----
+
+[#step-backup]
+=== Step 1: Back up your policies and policy servers
+
+Back up all your {policy-server} instances and policy custom resources.
+Because the community chart preserves user CRs on uninstall, this backup is a
+precaution rather than the primary recovery mechanism.
+
+include::partial$backup-policies.adoc[]
+
+[#step-capture-values]
+=== Step 2: Capture your existing values
+
+Save your current user-supplied values from the community release for
+reference. You will transform this file in Step 3. Replace
+`admission-controller` with your actual Helm release name if it differs.
+
+[source,sh]
+----
+helm get values admission-controller \
+  -n "$NAMESPACE" \
+  -o yaml > old-values.yaml
+----
+
+[#step-transform-values]
+=== Step 3: Transform your values for the {admc-name} conventions
+
+The top-level key names are identical in both charts. Only the image registry
+and pull-secret keys differ. Use the following `yq` command to remove the
+`global.cattle` block and move the top-level `imagePullSecrets` to
+`global.imagePullSecrets`:
+
+[source,sh]
+----
+yq eval '
+  del(.global.cattle) |
+  (.global.imagePullSecrets = (.imagePullSecrets // [])) |
+  del(.imagePullSecrets)
+' old-values.yaml > new-values.yaml
+----
+
+Review `new-values.yaml` before proceeding. If you did not customise the
+registry or pull secrets in the community chart, the output may be nearly
+empty, which is fine, since the {admc-name} chart defaults cover all required
+settings.
+
+See <<mapping-values>> for the complete list of key differences.
+
+[NOTE]
+====
+The `global.imagePullSecrets` value in the {admc-name} chart is a list of
+secret name strings or `{name: ...}` objects. You create the pull secret
+itself in Step 5. If you add it by name here in `new-values.yaml`, make sure
+the name matches what you create in Step 5.
+====
+
+[#step-registry-login]
+=== Step 4: Log in to the Application Collection registry
+
+[source,sh]
+----
+helm registry login dp.apps.rancher.io \
+  --username <your-username> \
+  --password <your-token>
+----
+
+[#step-pull-secret]
+=== Step 5: Create the image pull secret
+
+include::partial$create-image-pull-secret.adoc[]
+
+[#step-uninstall]
+=== Step 6: Uninstall the community chart
+
+Replace `admission-controller` with your actual Helm release name if it differs.
+
+[source,sh]
+----
+helm uninstall admission-controller -n "$NAMESPACE"
+----
+
+[NOTE]
+====
+The community chart keeps its CRDs (`helm.sh/resource-policy: keep`). Its
+cleanup hook deletes the **chart-managed** resources — the default
+`PolicyServer` and the recommended `ClusterAdmissionPolicies`, identified by
+the `kubewarden.io/managed-by: kubewarden-controller-defaults` label — together
+with their backing resources (Deployments, webhooks, Services, Secrets). Your
+**user-defined** PolicyServers and policies are preserved.
+
+The deleted chart-managed defaults are not lost: the {admc-name} chart's
+controller recreates them on install (via server-side apply, field owner
+`kubewarden-controller-defaults`) when `policyServer.enabled` or
+`recommendedPolicies.enabled` is set in your values. After uninstall, the CRDs
+and your user CRs remain in the cluster for the {admc-name} chart to adopt.
+There is still a short enforcement gap until the {admc-name} chart is ready.
+====
+
+[#step-install]
+=== Step 7: Install the {admc-name} chart and adopt the CRDs
+
+The CRDs surviving from the community release still carry its Helm ownership
+metadata (`meta.helm.sh/release-name` and `meta.helm.sh/release-namespace`).
+Installing the {admc-name} chart without `--take-ownership` fails with an
+error like this:
+
+----
+Error: ... invalid ownership metadata; annotation
+meta.helm.sh/release-name must equal "suse-security-admission-controller":
+current value is "admission-controller"
+----
+
+Pass `--take-ownership` to re-stamp the CRD ownership metadata for the new
+release. Because the install uses the same namespace as the community release,
+only the release-name dimension of the metadata changes.
+
+[source,sh,subs="attributes+"]
+----
+helm install suse-security-admission-controller \
+  {admc-chart-location} \
+  --version 1.0.0 \
+  -n "$NAMESPACE" \
+  --take-ownership \
+  --set global.imagePullSecrets={application-collection} \
+  --values new-values.yaml \
+  --wait
+----
+
+[#step-restore]
+=== Step 8: Update PolicyServer images
+
+Because user CRs survived the community chart uninstall, they are already
+present in the cluster. The default `PolicyServer` was deleted during uninstall
+and recreated by the new chart's controller, so patch the **live** PolicyServers
+in place rather than re-applying the backup — this updates both your user
+PolicyServers and the recreated default without creating duplicates. You only
+need to update any PolicyServer whose `spec.image` was pinned to the community
+image. The following command patches all live PolicyServers in place:
+
+[source,sh,subs="attributes+"]
+----
+kubectl get policyservers -A -o yaml \
+  | yq '.items[].spec.image = "{default-policy-server-image-tag}"' \
+  | kubectl apply -f -
+----
+
+[NOTE]
+====
+If a PolicyServer did not set `spec.image`, the controller uses the chart
+default and no change is needed. If any resource is unexpectedly missing after
+the uninstall, re-apply it from the Step 1 backup files, updating the
+PolicyServer image the same way:
+
+[source,sh,subs="attributes+"]
+----
+yq eval '.items[].spec.image = "{default-policy-server-image-tag}"' \
+  -i policyservers-backup.yaml
+kubectl apply -f policyservers-backup.yaml
+----
+
+Do not re-apply the entire backup once the chart's default resources have been
+recreated. `kubectl create` fails with `AlreadyExists` on the recreated
+defaults; `kubectl apply` (client-side) competes with the controller for field
+ownership of those resources (which the controller manages via server-side
+apply) and triggers a missing-annotation warning. Restore from backup only the
+individual **user** resources that are genuinely missing.
+====
+
+[#step-verify]
+=== Step 9: Verify the migration
+
+include::partial$verify-migration.adoc[]
+
+[#mapping-values]
+== Mapping your community chart values to the {admc-name} chart
+
+Both charts are flat and share identical top-level key names. Almost everything
+passes through unchanged. The only keys that differ are the image registry and
+the pull-secret key.
+
+[cols="2,2,2", options="header"]
+|===
+| Community key | {admc-name} key | Notes
+
+| `global.cattle.systemDefaultRegistry`
+| `global.imageRegistry`
+| Rename; omit to use the {admc-name} default (`dp.apps.rancher.io`)
+
+| `imagePullSecrets` (top-level)
+| `global.imagePullSecrets`
+| Normalize under `global`; both keys are read by the {admc-name} chart (via coalesce), with `global.imagePullSecrets` taking precedence
+
+| All other top-level keys (`logLevel`, `replicas`, `auditScanner.*`,
+  `policyServer.*`, `telemetry.*`, `mTLS.*`, `recommendedPolicies.*`,
+  `installOpenReportsCRDs`, `installPolicyReportCRDs`, `crdVersion`,
+  `nameOverride`, `fullnameOverride`, etc.)
+| Same key
+| Unchanged; carry over directly
+|===
+
+=== Image registry and pull secrets
+
+The registry convention changes from the Rancher-specific
+`global.cattle.systemDefaultRegistry` to the Application Collection standard
+`global.imageRegistry`. Do not carry `global.cattle.*` keys into the
+{admc-name} chart values; the chart ignores them.
+
+If you pull images from the default Application Collection registry
+(`dp.apps.rancher.io`), you do not need a registry override.
+
+If you pull images from a private mirror or an air-gapped registry:
+
+[source,yaml]
+----
+global:
+  imageRegistry: "my-private-registry.example.com"
+  imagePullSecrets:
+    - name: my-pull-secret
+----
+
+For pull secrets, the community chart used a top-level `imagePullSecrets` list.
+The {admc-name} chart reads both `global.imagePullSecrets` and a top-level
+`imagePullSecrets` (with `global.imagePullSecrets` taking precedence when both
+are set). The Step 3 `yq` command moves the list to `global.imagePullSecrets`
+(the preferred key) automatically.
+
+=== Recommended policies
+
+In the community chart, `recommendedPolicies.defaultPoliciesRegistry` defaults
+to `""`, which falls back to `global.cattle.systemDefaultRegistry` (`ghcr.io`).
+In the {admc-name} chart, `recommendedPolicies.defaultPoliciesRegistry`
+defaults to `ghcr.io` directly. The net result is the same.
+
+If you relied on `global.cattle.systemDefaultRegistry` to redirect policy
+modules to a private mirror, you must now set
+`recommendedPolicies.defaultPoliciesRegistry` explicitly in the {admc-name}
+chart values:
+
+[source,yaml]
+----
+recommendedPolicies:
+  defaultPoliciesRegistry: "my-private-registry.example.com"
+----
+
+The `recommendedPolicies.enabled` value defaults to `false` in both charts. If
+you had recommended policies enabled in the community setup, re-enable them
+explicitly in your new values.
+
+=== CRD toggles
+
+The two CRD installation toggles use the same top-level key names in both
+charts:
+
+* `installOpenReportsCRDs`
+* `installPolicyReportCRDs`
+
+Carry them over unchanged.
+
+[#caveats]
+== Caveats
+
+[#crd-adoption]
+=== CRD ownership adoption with `--take-ownership`
+
+The community chart keeps its CRDs on uninstall. When the {admc-name} chart
+installs into the same namespace under a different release name, the surviving
+CRDs still carry `meta.helm.sh/release-name: admission-controller`. Helm
+refuses to take over resources owned by another release without explicit
+consent.
+
+The `--take-ownership` flag (Helm 3.18+) re-stamps the CRD ownership metadata
+for the new release name. Since the install uses the same namespace, only the
+release-name annotation changes, while the namespace annotation stays consistent.
+
+The {admc-name} chart also annotates its CRDs with
+`helm.sh/resource-policy: keep`, so a future uninstall of the {admc-name}
+chart will leave the CRDs in place to protect any policies still running in the
+cluster.
+
+[#image-pull-secrets]
+=== Image pull secrets for policy-server pods
+
+include::partial$image-pull-secrets-caveat.adoc[]
+
+[#downtime-window]
+=== Policy enforcement gap
+
+Between Step 6 (uninstall the community chart) and Step 7 (the {admc-name}
+chart becoming ready), no admission controller is running. The webhook
+configurations are deleted by the community chart cleanup hook, so no admission
+evaluation takes place during this window.
+
+After the migration completes, run the Audit Scanner to identify any
+non-compliant resources that may have entered the cluster during the gap:
+
+[source,sh]
+----
+kubectl create job --from=cronjob/audit-scanner audit-scanner-manual -n "$NAMESPACE"
+----
+
+[#cattle-keys]
+=== `global.cattle.*` keys are ignored
+
+The {admc-name} chart does not read any key under `global.cattle`. In
+particular, `global.cattle.systemDefaultRegistry` and
+`global.cattle.imagePullSecrets` have no effect. Remove them from your values
+file and use `global.imageRegistry` and `global.imagePullSecrets` instead.

--- a/docs/version-1.37/modules/en/partials/product-specific/backup-policies.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/backup-policies.adoc
@@ -1,0 +1,10 @@
+[source,sh,subs="attributes+"]
+----
+FILTER='del(.items[].metadata.uid, .items[].metadata.resourceVersion, .items[].metadata.creationTimestamp, .items[].metadata.generation, .items[].metadata.managedFields, .items[].status)'
+
+kubectl get clusteradmissionpolicies {migration-backup-selector} -A -o yaml | yq "$FILTER" > clusteradmissionpolicies-backup.yaml
+kubectl get admissionpolicies -A -o yaml | yq "$FILTER" > admissionpolicies-backup.yaml
+kubectl get clusteradmissionpolicygroups -A -o yaml | yq "$FILTER" > clusteradmissionpolicygroups-backup.yaml
+kubectl get admissionpolicygroups -A -o yaml | yq "$FILTER" > admissionpolicygroups-backup.yaml
+kubectl get policyservers {migration-backup-selector} -A -o yaml | yq "$FILTER" > policyservers-backup.yaml
+----

--- a/docs/version-1.37/modules/en/partials/product-specific/create-image-pull-secret.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/create-image-pull-secret.adoc
@@ -1,0 +1,20 @@
+The {admc-name} chart pulls its component images (controller, audit-scanner,
+policy-server) from `dp.apps.rancher.io`, which is a private registry. Create an
+image pull secret in the `{migration-namespace}` namespace so the cluster can authenticate
+when pulling these images:
+
+[source,sh,subs="attributes+"]
+----
+kubectl create secret docker-registry application-collection \
+  -n {migration-namespace} \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<your-username> \
+  --docker-password=<your-token>
+----
+
+You reference this secret when installing the chart in the next step. See also
+<<image-pull-secrets>> for how to make the secret available to policy-server
+pods, and the
+https://docs.apps.rancher.io/get-started/deploy-helm-chart#helm-charts-standardizations[Application Collection Helm chart standardizations]
+for background on how `global.imagePullSecrets` works across all Application
+Collection charts.

--- a/docs/version-1.37/modules/en/partials/product-specific/image-pull-secrets-caveat.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/image-pull-secrets-caveat.adoc
@@ -1,0 +1,35 @@
+The {admc-name} chart pulls its component images from `dp.apps.rancher.io`, a
+private registry. The pull secret you create during installation is passed to
+the chart via `global.imagePullSecrets`. The controller reads this value and
+automatically adds those secrets to the `imagePullSecrets` field of every
+{policy-server} Deployment it manages, including any user-defined
+{policy-server} resources restored from a backup. No manual edit to individual
+{policy-server} resources is required.
+
+[IMPORTANT]
+====
+All {policy-server} pods run in the same namespace as the controller, the
+namespace where the chart is installed.
+ifdef::migration-namespace[]
+In this migration that namespace is `{migration-namespace}`.
+endif::[]
+The pull secret you create when installing the chart already exists in that
+namespace, so restored {policy-server} resources can pull their images without
+any extra step.
+====
+
+[NOTE]
+====
+`PolicyServer.spec.imagePullSecret` is a separate mechanism for providing
+credentials to the policy-server process when it fetches Wasm policy modules
+from a registry. It does not affect the pull secret used by the kubelet to pull
+the policy-server container image and will not resolve an `ImagePullBackOff`
+caused by a missing registry credential. Use `global.imagePullSecrets` (passed
+to the chart at install time) for container image pulls.
+====
+
+See the
+xref:howtos/policy-servers/02-private-registry.adoc[private registries how-to]
+for policy servers and the
+xref:howtos/application-collection/01-verify-images.adoc[Application Collection image verification how-to]
+for more detail.

--- a/docs/version-1.37/modules/en/partials/product-specific/variables.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/variables.adoc
@@ -1,0 +1,1 @@
+:default-container-image-tag: 1.37.0

--- a/docs/version-1.37/modules/en/partials/product-specific/verify-migration.adoc
+++ b/docs/version-1.37/modules/en/partials/product-specific/verify-migration.adoc
@@ -1,0 +1,49 @@
+Check that the CRDs are now owned by the new release and the controller is running:
+
+[source,sh,subs="attributes+"]
+----
+# CRDs owned by the new release
+kubectl get crd policyservers.policies.kubewarden.io \
+  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'
+
+# Controller running
+kubectl get deployment -n {migration-namespace} \
+  -l app.kubernetes.io/component=controller
+----
+
+Confirm that every backed-up resource is present in the cluster by comparing
+counts from the backup files against live cluster state. The `expected` and
+`actual` counts must match for each type:
+
+[source,sh]
+----
+for kind in policyservers clusteradmissionpolicies admissionpolicies \
+            clusteradmissionpolicygroups admissionpolicygroups; do
+  expected=$(yq '.items | length' "${kind}-backup.yaml")
+  actual=$(kubectl get "$kind" -A --no-headers 2>/dev/null | wc -l)
+  echo "$kind: expected=$expected actual=$actual"
+done
+----
+
+If any count does not match, apply the corresponding backup file and check the
+controller logs for errors.
+
+Check that all policies have reached `active` status. The controller reconciles
+them automatically:
+
+[source,sh]
+----
+kubectl get clusteradmissionpolicies
+kubectl get admissionpolicies -A
+kubectl get clusteradmissionpolicygroups
+kubectl get admissionpolicygroups -A
+----
+
+Confirm that every PolicyServer is using the {admc-name} policy-server image.
+Every `IMAGE` value must start with `dp.apps.rancher.io`:
+
+[source,sh]
+----
+kubectl get policyservers \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.image
+----


### PR DESCRIPTION
> [!WARNING]
> This should be released ONLY after the the Kubewarden admission controller v1.37.0 is GA!
> 
> This PR requires a sync from the community documentation repository to proper render. It uses attributes defined there but it still missing in this repository
 
# Description

Add the how-to for migrating from suse-security-admission-controller v0.8.0 (umbrella chart with three subcharts) to v1.0.0 (flat single chart), single community helm chart to the new AppCo, along with the shared partials and variable definitions it depends on to render, and its navigation entry.

Fix https://github.com/rancher/kubewarden/issues/73
Fix https://github.com/rancher/kubewarden/issues/72