### PR TITLE
fix: Use the correct git submodules paths

### DIFF
--- a/kw-rancher-dsc-local.yml
+++ b/kw-rancher-dsc-local.yml
@@ -12,7 +12,7 @@ ui:
   bundle:
     url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true
     snapshot: true
-  supplemental_files: ../../doc-suse-com/dsc-style-bundle/supplemental-files/rancher
+  supplemental_files: ./dsc-style-bundle/supplemental-files/rancher
 
 asciidoc:
   attributes:
@@ -33,10 +33,10 @@ antora:
       mermaid_library_url: https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs # <2>
       script_stem: header-scripts # <3>
       mermaid_initialize_options: # <4>
-    - require: ../product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
-      attributefile: ../product-docs-common/global-attributes.yml
+    - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
+      attributefile: ./product-docs-common/global-attributes.yml
       enabled: true
-    - require: ../product-docs-common/extensions/versions-latest-prerelease/vlp.js
+    - require: ./product-docs-common/extensions/versions-latest-prerelease/vlp.js
       enabled: true
 
 output:

--- a/kw-rancher-dsc.yml
+++ b/kw-rancher-dsc.yml
@@ -34,7 +34,7 @@ antora:
     - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
       attributefile: ./product-docs-common/global-attributes.yml
       enabled: true
-    - require: ../product-docs-common/extensions/versions-latest-prerelease/vlp.js
+    - require: ./product-docs-common/extensions/versions-latest-prerelease/vlp.js
       enabled: true
 
 output:


### PR DESCRIPTION
To be able to build locally with `make rancher-dsc-local`, consume the already present git submodules instead of using checkouts outside of the repo.